### PR TITLE
fix: make isLoading and error props optional in UserCount component

### DIFF
--- a/src/app/components/dashboardcomp/admin/UserCount.tsx
+++ b/src/app/components/dashboardcomp/admin/UserCount.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 interface UserCountProps {
     count: number | null;
-    isLoading: boolean;
-    error: string | null;
+    isLoading?: boolean;
+    error?: string | null;
 }
 
-const UserCount: React.FC<UserCountProps> = ({ count, isLoading, error }) => {
+const UserCount: React.FC<UserCountProps> = ({ count, isLoading = false, error = null }) => {
     return (
         <div className="bg-[#374151] rounded-lg p-4 mb-6">
             {isLoading ? (


### PR DESCRIPTION
This PR makes the isLoading and error props optional in the UserCount component to fix TypeScript errors in the build process.

Changes:
- Made isLoading and error props optional in UserCountProps interface
- Added default values for isLoading and error in the component
- This fixes the type error where these props were required but not always provided